### PR TITLE
[docs] Recommend shallow cloning the kernel repo.

### DIFF
--- a/linux_compile_firmware.md
+++ b/linux_compile_firmware.md
@@ -30,7 +30,7 @@ Download Linux SDK:
 # U-Boot
 git clone -b release https://github.com/FireflyTeam/u-boot
 # Kernel
-git clone -b release-4.4 https://github.com/FireflyTeam/kernel
+git clone -b release-4.4 https://github.com/FireflyTeam/kernel --depth=1
 # Build
 git clone -b debian https://github.com/FireflyTeam/build
 # Rkbin
@@ -38,8 +38,6 @@ git clone -b master https://github.com/FireflyTeam/rkbin
 ```
 
 You can also browse the source code online using the github links above.
-
-TODO: kernel.git is too big to download from github
 
 The board build config is inside:
 


### PR DESCRIPTION
### What does this PR do?
Resolves the deleted TODO about the kernel repo being painfully slow to clone -- there's really no reason to pull the entire history if you just want to build against a branch's `HEAD`, and I find it brings the clone time down to <1min even on cheap hardware.

Not sure if this should be included as well, but FWIW — once you've got a shallow working copy, you can always pull the full tree with `git fetch --unshallow`.